### PR TITLE
fix(STAR-1514): store and use output name when starting productions

### DIFF
--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -218,23 +218,35 @@ async function insertPipelineUuid(productionSettings: ProductionSettings) {
 
     pipelinePreset.pipeline_id = pipeline.uuid;
 
-    // Check if any outputs are configured, then update the UUID of them. This does currently not support that
-    // the pipeline has been reconfigured with fewer number of outputs than it had while the outputs was configured
-    // in the first place.
-    if (pipelinePreset.outputs) {
-      if (pipelinePreset.outputs!.length <= pipeline.outputs.length) {
-        for (let i = 0; i < pipelinePreset.outputs!.length; i++) {
-          Log().debug(
-            `Updating output from uuid: ${pipelinePreset.outputs![i].uuid} to ${
-              pipeline.outputs[i].uuid
-            }`
+    // Check if any outputs are configured, then update the UUID of them. If no output is found in the pipeline,
+    // the output is removed from the preset. If the output in the preset has no streams configured, remove it
+    // as well to clean up the object as much as possible.
+    if (pipelinePreset.outputs && pipelinePreset.outputs!.length > 0) {
+      for (const output of pipelinePreset.outputs!) {
+        if (output.streams.length == 0) {
+          Log().info(
+            `Output ${output.name} has no streams configured, removing output from preset`
           );
-          pipelinePreset.outputs![i].uuid = pipeline.outputs[i].uuid;
+          pipelinePreset.outputs = pipelinePreset.outputs.filter(
+            (o) => o != output
+          );
+          continue;
         }
-      } else if (pipelinePreset.outputs!.length > pipeline.outputs.length) {
-        const errorMessage = `The pipeline ${pipelinePreset.pipeline_name} has less outputs than number of configured outputs for the production, failing to start production`;
-        Log().error(errorMessage);
-        throw errorMessage;
+
+        Log().debug(`Trying to find uuid for output with name: ${output.name}`);
+        const pipelineOutput = pipeline.outputs.find(
+          (o) => o.name == output.name
+        );
+        if (pipelineOutput) {
+          output.uuid = pipelineOutput.uuid;
+        } else {
+          Log().info(
+            `No output found in the pipeline with name: ${output.name}, removing output from preset`
+          );
+          pipelinePreset.outputs = pipelinePreset.outputs?.filter(
+            (o) => o != output
+          );
+        }
       }
     }
   }

--- a/src/components/modal/configureOutputModal/PipelineOutputConfig.tsx
+++ b/src/components/modal/configureOutputModal/PipelineOutputConfig.tsx
@@ -67,15 +67,16 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
     updatePipelineOutputs(updatedOutputs);
   }, [updatedOutputs]);
 
-  const handleAddStream = (outputId: string) => {
+  const handleAddStream = (output: ResourcesNameAndUUIDResponse) => {
     const newOutputs: PipelineOutput[] = cloneDeep(updatedOutputs);
-    const foundOutput = newOutputs.find((o) => o.uuid === outputId);
+    const foundOutput = newOutputs.find((o) => o.uuid === output.uuid);
     const newStream = createNewStream(getPortNumber(), pipeline);
     if (foundOutput) {
       foundOutput?.streams.push(newStream);
     } else {
       newOutputs.push({
-        uuid: outputId,
+        uuid: output.uuid,
+        name: output.name,
         settings: getStreamEncoderSettings(pipeline),
         streams: [newStream]
       });
@@ -180,17 +181,18 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
   const handleUpdateOutputSetting = (
     key: keyof PipelineOutputEncoderSettings,
     value: string | number,
-    outputId: string
+    output: ResourcesNameAndUUIDResponse
   ) => {
     const newOutputs: PipelineOutput[] = cloneDeep(updatedOutputs);
-    let foundOutputIndex = newOutputs.findIndex((o) => o.uuid === outputId);
+    let foundOutputIndex = newOutputs.findIndex((o) => o.uuid === output.uuid);
     if (foundOutputIndex < 0) {
       newOutputs.push({
-        uuid: outputId,
+        uuid: output.uuid,
+        name: output.name,
         settings: getStreamEncoderSettings(pipeline),
         streams: []
       });
-      foundOutputIndex = newOutputs.findIndex((o) => o.uuid === outputId);
+      foundOutputIndex = newOutputs.findIndex((o) => o.uuid === output.uuid);
     }
 
     if (!newOutputs[foundOutputIndex].settings) {
@@ -207,11 +209,11 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
     setUpdatedOutputs(newOutputs);
   };
 
-  const getOutputFields = (outputId: string) => {
-    const foundOutput = updatedOutputs.find((p) => p.uuid === outputId);
+  const getOutputFields = (output: ResourcesNameAndUUIDResponse) => {
+    const foundOutput = updatedOutputs.find((p) => p.uuid === output.uuid);
 
     return (
-      <div className="flex flex-col gap-3" key={`${outputId}-options`}>
+      <div className="flex flex-col gap-3" key={`${output.uuid}-options`}>
         <Options
           label={t('preset.video_format')}
           options={[
@@ -223,7 +225,7 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
             getStreamEncoderSettings(pipeline).video_format
           }
           update={(value) =>
-            handleUpdateOutputSetting('video_format', value, outputId)
+            handleUpdateOutputSetting('video_format', value, output)
           }
         />
         <Options
@@ -243,7 +245,7 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
             getStreamEncoderSettings(pipeline).video_bit_depth.toString()
           }
           update={(value) =>
-            handleUpdateOutputSetting('video_bit_depth', value, outputId)
+            handleUpdateOutputSetting('video_bit_depth', value, output)
           }
         />
 
@@ -256,7 +258,7 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
             getStreamEncoderSettings(pipeline).video_kilobit_rate
           }
           update={(value) =>
-            handleUpdateOutputSetting('video_kilobit_rate', value, outputId)
+            handleUpdateOutputSetting('video_kilobit_rate', value, output)
           }
         />
       </div>
@@ -273,12 +275,12 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
             key={'output-settings-' + index}
           >
             <h1 className="font-bold text-center">{output.name}</h1>
-            {getOutputFields(output.uuid)}
+            {getOutputFields(output)}
             <div className="flex flex-col gap-3">
               {getOutputStreams(output.uuid)}
             </div>
             <button
-              onClick={() => handleAddStream(output.uuid)}
+              onClick={() => handleAddStream(output)}
               className="rounded-xl p-1 border border-gray-600 focus:border-gray-400 focus:outline-none hover:border-gray-500 p-3"
             >
               {t('preset.add_stream')}

--- a/src/interfaces/pipeline.ts
+++ b/src/interfaces/pipeline.ts
@@ -85,6 +85,7 @@ export interface PipelineSettings {
 
 export interface PipelineOutput {
   uuid: string;
+  name: string;
   settings: PipelineOutputEncoderSettings;
   streams: PipelineOutputSettings[];
 }


### PR DESCRIPTION
Fix the bug by storing the name of the output that is configured in the production object. Clean up not found and unused outputs as well. This avoids errors when a pipeline has been changed to one where some outputs doesn't exists. This would cause errors that the users would have a really hard time to fix without altering database or pipeline configurations.