### PR TITLE
fix: remove the check for outputs on same ip and port

### DIFF
--- a/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
+++ b/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
@@ -49,24 +49,6 @@ export function ConfigureOutputModal({
   }, [preset]);
 
   const onSave = () => {
-    const locations = pipelines
-      .map((p) =>
-        p.outputs?.map((o) =>
-          o.streams.map((s) => `${s.local_ip}:${s.local_port}`)
-        )
-      )
-      .flat(2);
-    function findDuplicates(array: any[]) {
-      return array.filter(
-        (currentValue, currentIndex) =>
-          array.indexOf(currentValue) !== currentIndex
-      );
-    }
-    const duplicates = findDuplicates(locations);
-    if (duplicates.length) {
-      setCurrentError('Same <IP>:<Port> used for multiple streams');
-      return;
-    }
     updatePreset({ ...preset, pipelines: pipelines });
     onClose();
   };


### PR DESCRIPTION
For SRT callers it can be valid to do multiple streams to same remote ip and port, the receiver may differentiate the streams using the stream IDs. For listerners on same machine this type of check could been ok to have, but not for pipelines on different machines. Removing the check completely for now.